### PR TITLE
Further handling of Infinity values in fair share parsing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Once you're ready to cut a new release, perform the following steps on the
 
 Tag the release version:
 
-`git tag -a v1.0.1 -m 'release note'`
+`git tag v1.0.1`
 
 Push the tag:
 
@@ -82,7 +82,7 @@ Push the tag:
 Make sure you have `GITHUB_TOKEN` exported, then use `goreleaser` to create
 releases:
 
-`goreleaser release`
+`goreleaser release --clean`
 
 ## Adding Support for New Openapi Versions
 

--- a/internal/api/unmarshalers_2311.go
+++ b/internal/api/unmarshalers_2311.go
@@ -5,6 +5,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	openapi "github.com/lcrownover/openapi-slurm-23-11"
 )
@@ -51,10 +52,28 @@ func UnmarshalPartitionsResponse(b []byte) (*openapi.V0040OpenapiPartitionResp, 
 
 // UnmarshalSharesResponse converts the response bytes into a slurm type
 func UnmarshalSharesResponse(b []byte) (*openapi.V0040OpenapiSharesResp, error) {
+	// this is disgusting but the response has values of "Infinity" which are
+	// not json unmarshal-able, so I manually replace all the "Infinity"s with the correct
+	// float64 value that represents Infinity.
+	// this will be fixed in v0.0.42
+	// https://support.schedmd.com/show_bug.cgi?id=20817
+	//
+	// https://github.com/lcrownover/prometheus-slurm-exporter/issues/8
+	// also reported that folks are getting "inf" back, so I'll protect for that too
+	sharesRespString := string(b)
+	maxFloatStr := ": 1.7976931348623157e+308"
+	sharesRespString = strings.ReplaceAll(sharesRespString, ": Infinity", maxFloatStr) // replacing the longer strings first should prevent any partial replacements
+	sharesRespString = strings.ReplaceAll(sharesRespString, ": infinity", maxFloatStr)
+	sharesRespString = strings.ReplaceAll(sharesRespString, ": Inf", maxFloatStr) // sometimes it'd return "inf", so let's cover for that too.
+	sharesRespString = strings.ReplaceAll(sharesRespString, ": inf", maxFloatStr)
+	sharesRespBytes := []byte(sharesRespString)
+	// end hack
+
 	var sharesResp openapi.V0040OpenapiSharesResp
-	err := json.Unmarshal(b, &sharesResp)
+	err := json.Unmarshal(sharesRespBytes, &sharesResp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall shares response data: %v", err)
 	}
+
 	return &sharesResp, nil
 }

--- a/testdata/V0040OpenapiSharesResp.json
+++ b/testdata/V0040OpenapiSharesResp.json
@@ -77,7 +77,7 @@
       },
       "usage" : 9,
       "fairshare" : {
-        "level" : 2.027123023002322,
+        "level" : Infinity,
         "factor" : 3.616076749251911
       },
       "type" : [ "USER", "USER" ],


### PR DESCRIPTION
Fixed the lack of Infinity handling in 23.11, added Infinity to test data to ensure it works.