### PR TITLE
Disable keepalive on unix sockets

### DIFF
--- a/internal/api/transport.go
+++ b/internal/api/transport.go
@@ -130,6 +130,7 @@ func newSlurmUnixRestRequest(ctx context.Context, k types.Key) (*slurmRestReques
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					return net.Dial("unix", socketPath)
 				},
+				DisableKeepAlives: true,
 			},
 		},
 	}, nil


### PR DESCRIPTION
The unix socket connections never seem to get dropped and then stop working once resource limits are reached in slurmrestd. Disable KeepAlive so that the connections are always closed after the request to fix this.