### PR TITLE
Export fairshare correctly for Slurm 24.11

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -715,11 +716,18 @@ func (s *ShareData) SetEffectiveUsage(effectiveUsage any) error {
 		return nil
 	}
 	// check if effectiveUsage is a struct
-	if effectiveUsageStruct, ok := effectiveUsage.(map[string]any); ok {
-		if number, ok := effectiveUsageStruct["number"]; ok {
-			if numberFloat, ok := number.(float64); ok {
-				s.EffectiveUsage = numberFloat
-			}
+	v := reflect.ValueOf(effectiveUsage)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Struct {
+		// field Number should be a *float64
+		number := v.FieldByName("Number")
+		if number.Kind() == reflect.Ptr {
+			number = number.Elem()
+		}
+		if number.CanFloat() {
+			s.EffectiveUsage = number.Float()
 		}
 	}
 	return nil

--- a/internal/slurm/fairshare.go
+++ b/internal/slurm/fairshare.go
@@ -69,7 +69,7 @@ func ParseFairShareMetrics(sharesData *api.SharesData) (map[string]*fairShareMet
 		if _, exists := accounts[account]; !exists {
 			accounts[account] = NewFairShareMetrics()
 		}
-		accounts[account].fairshare = s.EffectiveUsage
+		accounts[account].fairshare += s.EffectiveUsage
 	}
 	return accounts, nil
 }


### PR DESCRIPTION
Closes #34

Not sure if reflection is the way to go here since I have not used Go before, but at least it seems to work.

The previous attempted cast `effectiveUsage.(map[string]any)` seems to never succeed according to a step-by-step debugging, so changing `"number"` to `"Number"` in `if number, ok := effectiveUsageStruct["number"]; ok {` would not have fixed the issue.